### PR TITLE
Fix image

### DIFF
--- a/locals_advanced.tf
+++ b/locals_advanced.tf
@@ -2,7 +2,7 @@
 
 locals {
   # image is region-local. If you changed region, please also change image.
-  region = "us-east-2"
+  region = "us-west-2"
   image  = "ami-03f65b8614a860c29" # Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2023-05-16
 
   # If you want to change instance type, ensure that GP3 EBS is available in the instance type.

--- a/locals_advanced.tf
+++ b/locals_advanced.tf
@@ -3,7 +3,7 @@
 locals {
   # image is region-local. If you changed region, please also change image.
   region = "us-east-2"
-  image  = "ami-0fb653ca2d3203ac1" # Ubuntu 20.04
+  image  = "ami-03f65b8614a860c29" # Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2023-05-16
 
   # If you want to change instance type, ensure that GP3 EBS is available in the instance type.
   tidb_instance    = "c5.2xlarge"


### PR DESCRIPTION
To avoid errors like 
```
 Error: error collecting instance settings: InvalidAMIID.NotFound: The image id '[ami-0fb653ca2d3203ac1]' does not exist
│ 	status code: 400, request id: abb7b721-adf9-4a2c-92c1-78d4c88a381f
```