### PR TITLE
AMI ID: fix invalid AMI ID of us-east-1

### DIFF
--- a/locals_advanced.tf
+++ b/locals_advanced.tf
@@ -3,7 +3,7 @@
 locals {
   # image is region-local. If you changed region, please also change image.
   # AMIs of each region (Ubuntu 22.04 + OMZ + KernelTunes):
-  # us-east-1	ami-0e2732470fc684140
+  # us-east-1	ami-0c398cb65a93047f2
   # us-east-2	ami-05cda54fbc39e2381
   # us-west-1	ami-0575bfdeb6f59b5d8
   # us-west-2	ami-003e5556ddc999e13


### PR DESCRIPTION
The AMI ID is invalid
Before:
```
(base) ➜  ~ aws ec2 describe-images --region us-east-1 --image-ids      ami-0e2732470fc6841

An error occurred (InvalidAMIID.Malformed) when calling the DescribeImages operation: Invalid id: "ami-0e2732470fc6841"
```

After:
```
(base) ➜  ~ aws ec2 describe-images --region us-east-1 --image-ids ami-0c398cb65a93047f2

{
    "Images": [
        {
            "PlatformDetails": "Linux/UNIX",
            "UsageOperation": "RunInstances",
            "BlockDeviceMappings": [
                {
                    "Ebs": {
                        "DeleteOnTermination": true,
                        "SnapshotId": "snap-0631691c299b02084",
                        "VolumeSize": 8,
                        "VolumeType": "gp2",
                        "Encrypted": false
                    },
                    "DeviceName": "/dev/sda1"
                },
                {
                    "DeviceName": "/dev/sdb",
                    "VirtualName": "ephemeral0"
                },
                {
                    "DeviceName": "/dev/sdc",
                    "VirtualName": "ephemeral1"
                }
            ],
            "Description": "Canonical, Ubuntu, 22.04, amd64 jammy image",
            "EnaSupport": true,
            "Hypervisor": "xen",
            "ImageOwnerAlias": "amazon",
            "Name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20251015",
            "RootDeviceName": "/dev/sda1",
            "RootDeviceType": "ebs",
            "SriovNetSupport": "simple",
            "VirtualizationType": "hvm",
            "BootMode": "uefi-preferred",
            "DeprecationTime": "2027-10-15T08:05:51.000Z",
            "ImageId": "ami-0c398cb65a93047f2",
            "ImageLocation": "amazon/ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20251015",
            "State": "available",
            "OwnerId": "099720109477",
            "CreationDate": "2025-10-15T08:05:51.000Z",
            "Public": true,
            "Architecture": "x86_64",
            "ImageType": "machine"
        }
    ]
}
```