### PR TITLE
feat: support TiCDC deployment and allow n_tiflash=0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A sample to create VMs for deploying TiDB in AWS using [Terraform](https://www.t
 | TiKV                                        | 8c 64g | 3     | 172.31.6.1, 172.31.6.2, ... |
 | TiDB                                        | 8c 16g | 2     | 172.31.7.1, 172.31.7.2, ... |
 | PD + Grafana + Monitoring                   | 8c 16g | 1     | 172.31.8.1                  |
-| TiFlash                                     | 8c 64g | 0     | 172.31.9.1, 172.31.9.2, ... |
+| TiFlash                                     | 8c 64g | 1     | 172.31.9.1, 172.31.9.2, ... |
+| TiCDC                                       | 8c 16g | 0     | 172.31.10.1, 172.31.10.2, ... |
 | Center VM, you can run benchmarks and so on | 8c 16g | 1     | 172.31.1.1                  |
 
 The topology and instance size can be customized via [`locals_common.tf`](./locals_common.tf) and [`locals_advanced.tf`](./locals_advanced.tf).
@@ -35,16 +36,17 @@ terraform init
 
 ### 2. Optional: Configure
 
-Customize the number of TiDB and TiKV VMs in [`locals_common.tf`](./locals_common.tf).
+Customize the number of TiDB, TiKV, TiFlash, and TiCDC VMs in [`locals_common.tf`](./locals_common.tf).
 
 **Example:**
 
 ```terraform
 locals {
-  name      = "foo-benchmark"
+  namespace = "foo-benchmark"
   n_tidb    = 1  # default 2
   n_tikv    = 3  # default 3
-  n_tiflash = 0  # default 0
+  n_tiflash = 1  # default 1
+  n_ticdc   = 1  # default 0
 }
 ```
 
@@ -64,14 +66,18 @@ private-ip-tidb = [
   "172.31.7.1",
   "172.31.7.2",
 ]
-private-ip-tiflash = []
+private-ip-tiflash = [
+  "172.31.9.1",
+]
+private-ip-ticdc = []
 private-ip-tikv = [
   "172.31.6.1",
   "172.31.6.2",
   "172.31.6.3",
 ]
 ssh-center = "ssh ubuntu@<center_vm_ip>"
-tidb-dashboard = "http://<pd_vm_ip>:2379/dashboard"
+url-grafana = "http://<pd_vm_ip>:3000"
+url-tidb-dashboard = "http://<pd_vm_ip>:2379/dashboard"
 ```
 
 ### 4. Connect to Center VM and deploy cluster
@@ -119,5 +125,6 @@ terraform destroy -auto-approve
 | ✅     | With zsh                                    |
 | ✅     | TiDB recommended kernal parameters          |
 | ✅     | Support TiFlash                             |
+| ✅     | Support TiCDC                               |
 | ✅     | Instance size is identical with TiDB Cloud  |
 | ✅     | EC2 IAM Profile to access S3 without AK, SK |

--- a/data_cloudinit.tf
+++ b/data_cloudinit.tf
@@ -1,114 +1,115 @@
 locals {
 
-    cloudinit_merge_type = "list(append)+dict(no_replace,recurse_list)+str()"
+  cloudinit_merge_type = "list(append)+dict(no_replace,recurse_list)+str()"
 
-    userdata_add_alternative_ssh_public = <<-EOT
+  userdata_add_alternative_ssh_public = <<-EOT
     #!/bin/bash
     echo '${trimspace(file(local.alternative_ssh_public))}' | tee -a /home/${local.username}/.ssh/authorized_keys
     EOT
 
-    userdata_haproxy_cfg = <<-EOT
+  userdata_haproxy_cfg = <<-EOT
     #cloud-config
     ${yamlencode({
-        write_files = [{
-            path        = "/home/${local.username}/haproxy.cfg"
-            permissions = "0644"
-            owner       = "${local.username}:${local.username}"
-            encoding    = "b64"
-            content     = base64encode(templatefile("./files/haproxy.cfg.tftpl", {
-                tidb_hosts = local.tidb_private_ips,
-            }))
-        }]
-    })}
+  write_files = [{
+    path        = "/home/${local.username}/haproxy.cfg"
+    permissions = "0644"
+    owner       = "${local.username}:${local.username}"
+    encoding    = "b64"
+    content = base64encode(templatefile("./files/haproxy.cfg.tftpl", {
+      tidb_hosts = local.tidb_private_ips,
+    }))
+  }]
+})}
     EOT
 
-    userdata_topology_yaml = <<-EOT
+userdata_topology_yaml = <<-EOT
     #cloud-config
     ${yamlencode({
-        write_files = [{
-            path        = "/home/${local.username}/topology.yaml"
-            permissions = "0644"
-            owner       = "${local.username}:${local.username}"
-            encoding    = "b64"
-            content     = base64encode(templatefile("./files/topology.yaml.tftpl", {
-                tidb_hosts = local.tidb_private_ips,
-                tikv_hosts = local.tikv_private_ips,
-                tiflash_hosts = local.tiflash_private_ips,
-                s3_region = local.region,
-            }))
-        }]
-    })}
+write_files = [{
+  path        = "/home/${local.username}/topology.yaml"
+  permissions = "0644"
+  owner       = "${local.username}:${local.username}"
+  encoding    = "b64"
+  content = base64encode(templatefile("./files/topology.yaml.tftpl", {
+    tidb_hosts    = local.tidb_private_ips,
+    tikv_hosts    = local.tikv_private_ips,
+    tiflash_hosts = local.tiflash_private_ips,
+    ticdc_hosts   = local.ticdc_private_ips,
+    s3_region     = local.region,
+  }))
+}]
+})}
     EOT
 
-    userdata_master_ssh_pairs = <<-EOT
+userdata_master_ssh_pairs = <<-EOT
     #cloud-config
     ${yamlencode({
-        write_files = [{
-            path        = "/home/${local.username}/.ssh/id_rsa"
-            permissions = "0400"
-            owner       = "${local.username}:${local.username}"
-            encoding    = "b64"
-            content     = base64encode(file(local.master_ssh_key))
-        }, {
-            path        = "/home/${local.username}/.ssh/id_rsa.pub"
-            permissions = "0644"
-            owner       = "${local.username}:${local.username}"
-            encoding    = "b64"
-            content     = base64encode(file(local.master_ssh_public))
-        }]
-    })}
+write_files = [{
+  path        = "/home/${local.username}/.ssh/id_rsa"
+  permissions = "0400"
+  owner       = "${local.username}:${local.username}"
+  encoding    = "b64"
+  content     = base64encode(file(local.master_ssh_key))
+  }, {
+  path        = "/home/${local.username}/.ssh/id_rsa.pub"
+  permissions = "0644"
+  owner       = "${local.username}:${local.username}"
+  encoding    = "b64"
+  content     = base64encode(file(local.master_ssh_public))
+}]
+})}
     EOT
 
 }
 
 # For all servers except for center server, use the following cloudinit config.
 data "cloudinit_config" "common_server" {
-    gzip          = true
-    base64_encode = true
+  gzip          = true
+  base64_encode = true
 
-    part {
-        content_type = "text/x-shellscript"
-        filename     = "add_ssh.sh"
-        content      = local.userdata_add_alternative_ssh_public
-    }
+  part {
+    content_type = "text/x-shellscript"
+    filename     = "add_ssh.sh"
+    content      = local.userdata_add_alternative_ssh_public
+  }
 }
 
 # For center server, use the following cloudinit config.
 data "cloudinit_config" "center_server" {
-    gzip          = true
-    base64_encode = true
+  gzip          = true
+  base64_encode = true
 
-    part {
-        content_type = "text/cloud-config"
-        filename     = "write_haproxy.cfg"
-        content      = local.userdata_haproxy_cfg
-        merge_type   = local.cloudinit_merge_type
-    }
+  part {
+    content_type = "text/cloud-config"
+    filename     = "write_haproxy.cfg"
+    content      = local.userdata_haproxy_cfg
+    merge_type   = local.cloudinit_merge_type
+  }
 
-    part {
-        content_type = "text/cloud-config"
-        filename     = "write_topology.cfg"
-        content      = local.userdata_topology_yaml
-        merge_type   = local.cloudinit_merge_type
-    }
+  part {
+    content_type = "text/cloud-config"
+    filename     = "write_topology.cfg"
+    content      = local.userdata_topology_yaml
+    merge_type   = local.cloudinit_merge_type
+  }
 
-    part {
-        content_type = "text/cloud-config"
-        filename     = "write_master_ssh_pairs.cfg"
-        content      = local.userdata_master_ssh_pairs
-        merge_type   = local.cloudinit_merge_type
-    }
+  part {
+    content_type = "text/cloud-config"
+    filename     = "write_master_ssh_pairs.cfg"
+    content      = local.userdata_master_ssh_pairs
+    merge_type   = local.cloudinit_merge_type
+  }
 
-    part {
-        content_type = "text/x-shellscript"
-        filename     = "add_ssh.sh"
-        content      = local.userdata_add_alternative_ssh_public
-    }
+  part {
+    content_type = "text/x-shellscript"
+    filename     = "add_ssh.sh"
+    content      = local.userdata_add_alternative_ssh_public
+  }
 
-    part {
-        content_type = "text/x-shellscript"
-        filename     = "cloudinit_center.sh"
-        content      = file("./files/cloudinit_center.sh")
-    }
+  part {
+    content_type = "text/x-shellscript"
+    filename     = "cloudinit_center.sh"
+    content      = file("./files/cloudinit_center.sh")
+  }
 
 }

--- a/files/topology.yaml.tftpl
+++ b/files/topology.yaml.tftpl
@@ -7,7 +7,12 @@ server_configs:
   tidb: {}
   tikv: {}
   pd: {}
+  %{~ if length(tiflash_hosts) > 0 ~}
   tiflash: {}
+  %{~ endif ~}
+  %{~ if length(ticdc_hosts) > 0 ~}
+  cdc: {}
+  %{~ endif ~}
 
 tidb_servers:
   %{~ for host in tidb_hosts ~}
@@ -19,10 +24,19 @@ tikv_servers:
   - host: ${host}
   %{~ endfor ~}
 
+%{~ if length(tiflash_hosts) > 0 ~}
 tiflash_servers:
   %{~ for host in tiflash_hosts ~}
   - host: ${host}
   %{~ endfor ~}
+%{~ endif ~}
+
+%{~ if length(ticdc_hosts) > 0 ~}
+cdc_servers:
+  %{~ for host in ticdc_hosts ~}
+  - host: ${host}
+  %{~ endfor ~}
+%{~ endif ~}
 
 pd_servers:
   - host: 172.31.8.1

--- a/locals_advanced.tf
+++ b/locals_advanced.tf
@@ -15,6 +15,7 @@ locals {
   tikv_instance    = "r5.2xlarge"
   pd_instance      = "c5.2xlarge"
   tiflash_instance = "r5.2xlarge"
+  ticdc_instance   = "c5.2xlarge"
   center_instance  = "c5.2xlarge"
 
   master_ssh_key         = "./master_key"

--- a/locals_common.tf
+++ b/locals_common.tf
@@ -2,6 +2,7 @@ locals {
   namespace = "example-cluster"
   n_tidb    = 2
   n_tikv    = 3
-  n_tiflash = 1
+  n_tiflash = 0
+  n_ticdc   = 3
   username  = "ubuntu"
 }

--- a/main.tf
+++ b/main.tf
@@ -24,11 +24,12 @@ resource "aws_key_pair" "master_key" {
 }
 
 locals {
-  pd_private_ip = "172.31.8.1"
-  tidb_private_ips = [for i in range(local.n_tidb) : "172.31.7.${i + 1}"]
-  tikv_private_ips = [for i in range(local.n_tikv) : "172.31.6.${i + 1}"]
+  pd_private_ip       = "172.31.8.1"
+  tidb_private_ips    = [for i in range(local.n_tidb) : "172.31.7.${i + 1}"]
+  tikv_private_ips    = [for i in range(local.n_tikv) : "172.31.6.${i + 1}"]
   tiflash_private_ips = [for i in range(local.n_tiflash) : "172.31.9.${i + 1}"]
-  center_private_ip = "172.31.1.1"
+  ticdc_private_ips   = [for i in range(local.n_ticdc) : "172.31.10.${i + 1}"]
+  center_private_ip   = "172.31.1.1"
 }
 
 resource "aws_instance" "tidb" {
@@ -132,6 +133,33 @@ resource "aws_instance" "tiflash" {
 
   tags = {
     Name = "${local.namespace}-tiflash-write-${count.index}"
+  }
+
+  user_data_base64 = data.cloudinit_config.common_server.rendered
+}
+
+resource "aws_instance" "ticdc" {
+  count = local.n_ticdc
+
+  ami                         = local.image
+  instance_type               = local.ticdc_instance
+  key_name                    = aws_key_pair.master_key.id
+  vpc_security_group_ids      = [aws_security_group.ssh.id]
+  iam_instance_profile        = aws_iam_instance_profile.ec2_profile.name
+  subnet_id                   = aws_subnet.main.id
+  associate_public_ip_address = true
+  private_ip                  = local.ticdc_private_ips[count.index]
+
+  root_block_device {
+    volume_size           = 100
+    delete_on_termination = true
+    volume_type           = "gp3"
+    iops                  = 3000
+    throughput            = 125
+  }
+
+  tags = {
+    Name = "${local.namespace}-ticdc-${count.index}"
   }
 
   user_data_base64 = data.cloudinit_config.common_server.rendered

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,6 +22,10 @@ output "private-ip-tiflash" {
   value = local.tiflash_private_ips
 }
 
+output "private-ip-ticdc" {
+  value = local.ticdc_private_ips
+}
+
 output "private-ip-pd" {
   value = local.pd_private_ip
 }

--- a/resource_iam.tf
+++ b/resource_iam.tf
@@ -4,9 +4,9 @@ resource "aws_iam_policy" "ec2_policy" {
     Version = "2012-10-17"
     Statement = [
       {
-        "Effect": "Allow",
-        "Action": "s3:*",
-        "Resource": "*"
+        "Effect" : "Allow",
+        "Action" : "s3:*",
+        "Resource" : "*"
       }
     ]
   })
@@ -37,5 +37,5 @@ resource "aws_iam_policy_attachment" "ec2_policy_role" {
 
 resource "aws_iam_instance_profile" "ec2_profile" {
   name_prefix = local.namespace
-  role = aws_iam_role.ec2_role.name
+  role        = aws_iam_role.ec2_role.name
 }


### PR DESCRIPTION
## Summary

- add TiCDC deployment support in Terraform (instance count/spec, EC2 resource, private IP output)
- include TiCDC nodes in generated `topology.yaml`
- make `tiflash`/`tiflash_servers` conditional in topology template so `n_tiflash = 0` still works
- make `cdc`/`cdc_servers` conditional similarly for `n_ticdc = 0`
- update README with TiCDC topology/config examples and output samples

## Testing

- `terraform fmt -check -recursive`
- `terraform validate`
- `terraform console` template checks:
  - with `tiflash_hosts=[]`, rendered topology does not contain `tiflash_servers:`
  - with non-empty `tiflash_hosts`, rendered topology contains `tiflash_servers:`